### PR TITLE
fix: имена контейнеров ломаются на дефисах в shortUuid (#12)

### DIFF
--- a/backend/src/olcrtc/router.py
+++ b/backend/src/olcrtc/router.py
@@ -15,7 +15,8 @@ async def get_all(_admin: dict = Depends(get_current_admin)) -> list[ContainerSc
 @router.post("/run")
 async def run(name: str, _admin: dict = Depends(get_current_admin)):
     # Block starting a container when its owner has exceeded their traffic limit.
-    parts = name.split("-")
+    # maxsplit=2: Remnawave shortUuid contains hyphens
+    parts = name.split("-", 2)
     if len(parts) == 3 and parts[0] == "olcwave":
         try:
             traffic = await Users.get_traffic(parts[2])

--- a/backend/src/olcrtc/router.py
+++ b/backend/src/olcrtc/router.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 
 from auth.dependencies import get_current_admin
 from xraycore.sdk import XrayCore
+from olcrtc.sdk import OlcRTC
 from olcrtc.schemas import ContainerSchema, ContainerConfigSchema, ContainerLogsSchema, ContainerStatsSchema
 from olcrtc.service import Containers
 from users.service import Users
@@ -15,11 +16,10 @@ async def get_all(_admin: dict = Depends(get_current_admin)) -> list[ContainerSc
 @router.post("/run")
 async def run(name: str, _admin: dict = Depends(get_current_admin)):
     # Block starting a container when its owner has exceeded their traffic limit.
-    # maxsplit=2: Remnawave shortUuid contains hyphens
-    parts = name.split("-", 2)
-    if len(parts) == 3 and parts[0] == "olcwave":
+    parsed = OlcRTC.parse_name(name)
+    if parsed is not None:
         try:
-            traffic = await Users.get_traffic(parts[2])
+            traffic = await Users.get_traffic(parsed[1])
         except Exception:
             traffic = None
         if traffic and traffic.exceeded:

--- a/backend/src/olcrtc/sdk.py
+++ b/backend/src/olcrtc/sdk.py
@@ -9,6 +9,20 @@ import docker_client
 
 class OlcRTC:
     @staticmethod
+    def parse_name(name: str) -> tuple[str, str] | None:
+        """Split "olcwave-<config_tag>-<owner>" into (config_tag, owner).
+
+        maxsplit=2: a Remnawave shortUuid contains hyphens, while
+        config_tag never does (stripped on save).
+        """
+        parts = name.split("-", 2)
+
+        if len(parts) != 3 or parts[0] != "olcwave":
+            return None
+
+        return parts[1], parts[2]
+
+    @staticmethod
     async def build(rebuild: bool = False):
         docker = docker_client.docker
         if not rebuild:

--- a/backend/src/olcrtc/service.py
+++ b/backend/src/olcrtc/service.py
@@ -18,7 +18,8 @@ class Containers:
         info = await cont.show()
 
         name = info["Name"].lstrip("/")
-        parts = name.split("-")
+        # maxsplit=2: Remnawave shortUuid contains hyphens
+        parts = name.split("-", 2)
 
         return len(parts) == 3 and parts[0] == "olcwave"
 
@@ -27,7 +28,8 @@ class Containers:
         info = await cont.show()
 
         name = info["Name"].lstrip("/")
-        parts = name.split("-")
+        # maxsplit=2: Remnawave shortUuid contains hyphens
+        parts = name.split("-", 2)
 
         if len(parts) != 3:
             return None

--- a/backend/src/olcrtc/service.py
+++ b/backend/src/olcrtc/service.py
@@ -18,23 +18,20 @@ class Containers:
         info = await cont.show()
 
         name = info["Name"].lstrip("/")
-        # maxsplit=2: Remnawave shortUuid contains hyphens
-        parts = name.split("-", 2)
 
-        return len(parts) == 3 and parts[0] == "olcwave"
+        return OlcRTC.parse_name(name) is not None
 
     @staticmethod
     async def to_schema(cont: DockerContainer) -> ContainerSchema | None:
         info = await cont.show()
 
         name = info["Name"].lstrip("/")
-        # maxsplit=2: Remnawave shortUuid contains hyphens
-        parts = name.split("-", 2)
+        parsed = OlcRTC.parse_name(name)
 
-        if len(parts) != 3:
+        if parsed is None:
             return None
 
-        _, config_tag, user_id = parts
+        config_tag, user_id = parsed
 
         return ContainerSchema(
             id=info["Id"][:12],

--- a/backend/src/traffic.py
+++ b/backend/src/traffic.py
@@ -13,7 +13,8 @@ class TrafficManager:
 
     @staticmethod
     def _owner_of(name: str) -> str | None:
-        parts = name.split("-")
+        # maxsplit=2: Remnawave shortUuid contains hyphens
+        parts = name.split("-", 2)
 
         if len(parts) == 3 and parts[0] == "olcwave":
             return parts[2]

--- a/backend/src/traffic.py
+++ b/backend/src/traffic.py
@@ -12,16 +12,6 @@ class TrafficManager:
     _last_totals: dict[str, int] = {}
 
     @staticmethod
-    def _owner_of(name: str) -> str | None:
-        # maxsplit=2: Remnawave shortUuid contains hyphens
-        parts = name.split("-", 2)
-
-        if len(parts) == 3 and parts[0] == "olcwave":
-            return parts[2]
-
-        return None
-
-    @staticmethod
     async def _collect_deltas() -> dict[str, int]:
         deltas: dict[str, int] = {}
         seen: set[str] = set()
@@ -35,10 +25,12 @@ class TrafficManager:
             if not await Containers.is_panel_container(cont):
                 continue
 
-            owner = TrafficManager._owner_of(name)
+            parsed = OlcRTC.parse_name(name)
 
-            if owner is None:
+            if parsed is None:
                 continue
+
+            owner = parsed[1]
 
             seen.add(name)
 
@@ -81,7 +73,9 @@ class TrafficManager:
             if not await Containers.is_panel_container(cont):
                 continue
 
-            if TrafficManager._owner_of(name) != short_uuid:
+            parsed = OlcRTC.parse_name(name)
+
+            if parsed is None or parsed[1] != short_uuid:
                 continue
 
             try:

--- a/backend/tests/test_container_names.py
+++ b/backend/tests/test_container_names.py
@@ -1,0 +1,37 @@
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from olcrtc.sdk import OlcRTC
+
+
+class ParseNameTest(unittest.TestCase):
+    """OlcRTC.parse_name decodes "olcwave-<config_tag>-<owner>"."""
+
+    def test_owner_may_contain_hyphens(self):
+        # a Remnawave shortUuid is not hyphen-free
+        self.assertEqual(
+            OlcRTC.parse_name("olcwave-wbvp8-X6kHaphfAzZJ-E-n"),
+            ("wbvp8", "X6kHaphfAzZJ-E-n"),
+        )
+
+    def test_plain_owner(self):
+        self.assertEqual(
+            OlcRTC.parse_name("olcwave-wbvp8-plainuuid"),
+            ("wbvp8", "plainuuid"),
+        )
+
+    def test_service_container_is_not_a_user_container(self):
+        self.assertIsNone(OlcRTC.parse_name("olcwave-xraycore"))
+
+    def test_foreign_container(self):
+        self.assertIsNone(OlcRTC.parse_name("some-other-container"))
+
+    def test_prefix_only(self):
+        self.assertIsNone(OlcRTC.parse_name("olcwave"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Закрывает #12.

## Проблема

Имя контейнера — `olcwave-<config_tag>-<short_uuid>` (`olcrtc/sdk.py`), а разбирается
оно через `name.split("-")` с проверкой `len(parts) == 3`. shortUuid из Remnawave
содержит дефисы (например `X6kHaphfAzZJ-E-n`), поэтому
`"olcwave-wbvp8-X6kHaphfAzZJ-E-n".split("-")` даёт 5 частей и проверка не проходит.

`config_tag` дефисы терять не может: они срезаются при сохранении профиля
(`profiles/service.py`, `tag.replace("-", "")`), поэтому `maxsplit=2` собирает
владельца целиком.

## Что затронуто

- `olcrtc/service.py` → `is_panel_container()` — контейнер не считается «своим»;
- `olcrtc/service.py` → `to_schema()` — возвращает `None`, панель не показывает контейнер;
- `traffic.py` → `_owner_of()` — трафик не учитывается, авто-стоп по лимиту не срабатывает;
- `olcrtc/router.py` → `POST /containers/run` — **этого места не было в issue**: заслон
  «не запускать контейнер при исчерпанном лимите» молча не срабатывает для
  Remnawave-пользователей, контейнер стартует из UI несмотря на превышение.

## Коммиты

1. **fix** — минимальная правка: `split("-", 2)` в четырёх местах.
2. **refactor** — разбор имени вынесен в `OlcRTC.parse_name()` рядом с кодом, который
   это имя собирает; `TrafficManager._owner_of` (обёртка в одну строку) удалён.
3. **test** — 5 тестов на разбор имени.

Второй и третий коммиты необязательны: если рефакторинг не нужен, достаточно смержить первый.

## Тесты

Голый `unittest`, новых зависимостей не добавлено:

```
cd backend && python -m unittest discover -s tests
```

Кейсы: `olcwave-wbvp8-X6kHaphfAzZJ-E-n` → `("wbvp8", "X6kHaphfAzZJ-E-n")`,
`olcwave-wbvp8-plainuuid` → `("wbvp8", "plainuuid")`, а `olcwave-xraycore`,
`some-other-container` и `olcwave` → `None` (прежнее поведение сохранено).
Если вернуть `parse_name` к обычному `split("-")`, падает `test_owner_may_contain_hyphens`.

## Проверка на боевой установке

`RW_ENABLED=True`: после правки панель видит контейнер пользователя с shortUuid
`X6kHaphfAzZJ-E-n` и корректно его парсит.

`subscriptions/service.py:157` (`name.split("-")[1]`) не трогал — там берётся тег по
индексу 1, он и так корректен.